### PR TITLE
remove simpleswap.io address from youtube scams

### DIFF
--- a/address.json
+++ b/address.json
@@ -67,7 +67,6 @@
     "13xuoAwwqfZuyAsRuUBasa8AhjdqzRbdyS3m52Lu6oCpFQRv",
     "1461Dsvr9GmkRjUkdJcYGP6HFygwQeZcspc6W5QgJVAT59yt",
     "14gWkqi6J3U4mcRTCi7yy824S2GepSNqpM4xNjLTCzGQpCst",
-    "14QsifyV7XyEDay8C862PNLRngid2AGZmtCwz1K88x5gpf58",
     "1X3M7sGA1Nbgd8Qh45uqdQMPNFXSHbWnvPp6CkQ9Ttp46dQ"
   ]
 }


### PR DESCRIPTION
Issue #69 provided several addresses relating to a scam.

The final address, `14QsifyV7XyEDay8C862PNLRngid2AGZmtCwz1K88x5gpf58`, is an address of simpleswap.io; a service the scammer must've used to exfiltrate the funds.

simpleswap.io itself is not a threat, and they have written to W3F's support team to fix the unjust warning.

This PR removes the address from `addresses.json`