### PR TITLE
Add https://atomicwalletgift.live/

### DIFF
--- a/all.json
+++ b/all.json
@@ -2,6 +2,7 @@
   "allow": [],
   "deny": [
     "4dot.net",
+    "atomicwalletgift.live",
     "claimpolka.live",
     "dot-event.news",
     "dot-event.org",


### PR DESCRIPTION
This a phishing attack on Atomic Wallet, but since that supports DOT and we are seeing scammers send people to this in the /r/DOT subreddit, I am adding it here.