### PR TITLE
Update address.json

### DIFF
--- a/address.json
+++ b/address.json
@@ -91,5 +91,8 @@
     "1461Dsvr9GmkRjUkdJcYGP6HFygwQeZcspc6W5QgJVAT59yt",
     "14gWkqi6J3U4mcRTCi7yy824S2GepSNqpM4xNjLTCzGQpCst",
     "1X3M7sGA1Nbgd8Qh45uqdQMPNFXSHbWnvPp6CkQ9Ttp46dQ"
+  ],
+  "twitter.com":[
+    "15MGfKyXwLuuBndsiz25CJXjzR7Xp4SwTXkYJR2nNY5MGrPE"
   ]
 }


### PR DESCRIPTION
Address reported by a user. Ticket 3306.

User was using Trustwallet, which had some issues. He reached out to them on Twitter and got phished by an impersonator who got access to their seed phrase and emptied their wallet. This is the direct transaction from the user's wallet, as reported by them:
https://polkadot.subscan.io/extrinsic/0x8798dfd61aea0913c123b4ed87cd2b470b0c8eabcf12374e6590aaf7759afe9d