### PR TITLE
Update address.json

### DIFF
--- a/address.json
+++ b/address.json
@@ -9,6 +9,9 @@
   "dot4.top": [
     "1Z5ohZkHN4TjWeKpcA3tqpd4uNSA3r9fzsEG9aviDUWAeo2"
   ],
+  "dot21.net": [
+    "1Z5ohZkHN4TjWeKpcA3tqpd4uNSA3r9fzsEG9aviDUWAeo2"
+  ],
   "dotevent.org": [
     "12759G1BVPC7cAb5tT8qLzDJUcnBuyW3n3icMwAA8uWGiUtT",
     "1ZkzFrJ3jecDVQ4oLWJ2fEftUUc2aSAyN8kAPLrV2dFJt3K"


### PR DESCRIPTION
Added new freshly registered bad URL, same wallet as previously seen one, thus same threat actor behind the scam
dot21[.]net
![image](https://user-images.githubusercontent.com/49607867/110204399-6f668900-7e7b-11eb-8656-9939a7cbf977.png)
