### PR TITLE
Add new bad URL

### DIFF
--- a/all.json
+++ b/all.json
@@ -27,6 +27,7 @@
     "polkadot-airdrop.org",
     "polkadot-airdropevent.network",
     "polkadot-airdrops.net",
+    "polkadot-airdrops.live",
     "polkadot-bonus.network",
     "polkadot-distribution.live",
     "polkadot-dot.info",


### PR DESCRIPTION
Add new bad URL, registered today, on bad IP hosting only scams.
polkadot-airdrops.live [198.187.29.28]
Scam is not even set up yet.
![image](https://user-images.githubusercontent.com/49607867/112650778-69e5d880-8e54-11eb-90f1-8ae526788050.png)

Staying ahead of the scammers!