### PR TITLE
add new bad url, just registered

### DIFF
--- a/all.json
+++ b/all.json
@@ -66,6 +66,7 @@
     "polkawallets.site",
     "polkdot-live.network",
     "polkodot.network",
+    "polkamon.whitelist-network.com",
     "wallet-linker.net",
     "wallet-syncing.com",
     "wallet-validation.site",


### PR DESCRIPTION
Pretty high confidence this is a future phish targeting polkadot, due to the deceptive domain name and bad IP used in numerous other scams historically.
Nuking in advance.
https://urlscan.io/ip/162.0.215.24
![image](https://user-images.githubusercontent.com/49607867/112674329-74ad6700-8e6e-11eb-9145-c83bb734c00a.png)
