### PR TITLE
Add new bad URL

### DIFF
--- a/all.json
+++ b/all.json
@@ -35,6 +35,7 @@
     "polkadot-dot.info",
     "polkadot-event.com",
     "polkadot-get.com",
+    "polkadot-get.org",
     "polkadot-js.online",
     "polkadot-js.site",
     "polkadot-live.network",


### PR DESCRIPTION
Domain: polkadot-get.org
![image](https://user-images.githubusercontent.com/49607867/112747859-b64e2700-8fc0-11eb-9da3-e5407de36f25.png)

Registrar: Regional Network Information Center, JSC dba RU-CENTER
Registered On: 2021-03-16
Scam wallet: 1s3B8f5dJbtV4rVTZs1WNRpzKCUJWxK2zULErjmA52Do2SF