### PR TITLE
Add new bad URL

### DIFF
--- a/all.json
+++ b/all.json
@@ -67,6 +67,7 @@
     "polkadotunlockwallet.com",
     "polkadotwallet-unlock.org",
     "polkamon.whitelist-network.com",
+    "polkamon.co",
     "polkawallets.site",
     "polkdot-live.network",
     "polkodot.network",


### PR DESCRIPTION
Bogus token "0x6B39f494fb6c9b1193f9E0fBd2Ed3d9D2Be2b18f"
Fake sence of urgency - hurry only 40 minutes left until sale ends bla bla.
![image](https://user-images.githubusercontent.com/49607867/112794548-b78a5d00-906f-11eb-8da1-a08ab3f82a63.png)

Bad wallet shared with nansen.
The same IP [68.65.122.223](https://www.virustotal.com/gui/ip-address/68.65.122.223/relations) also hosts a fake UniSwap clone and so on.