### PR TITLE
Add new bad url

### DIFF
--- a/all.json
+++ b/all.json
@@ -34,6 +34,7 @@
     "polkadot-autopool.com",
     "polkadot-bonus.network",
     "polkadot-bonus.org",
+    "polkadot-bonus.live",
     "polkadot-distribution.live",
     "polkadot-dot.info",
     "polkadot-event.com",


### PR DESCRIPTION
Another day, another scam.
Domain: polkadot-bonus.live
Registrar: Hostinger, UAB
Registered On: 2021-03-28

Scam facade is up:
![image](https://user-images.githubusercontent.com/49607867/112865532-8f2b4e80-90c1-11eb-973e-369b28a53c50.png)

Actual sub-scam page with DOT wallet is not up yet:
![image](https://user-images.githubusercontent.com/49607867/112865547-93576c00-90c1-11eb-8012-95776f64326f.png)


