### PR TITLE
Add new bad url

### DIFF
--- a/all.json
+++ b/all.json
@@ -75,6 +75,7 @@
     "polkamon.co",
     "polkamon.whitelist-network.com",
     "polkastarter.ws",
+    "polkastarter.ai",
     "polkawallets.site",
     "polkdot-live.network",
     "polkodot.network",


### PR DESCRIPTION
Not necessarily polkadot phishing per se, more like rug pull / pump and dump token abusing the projects good name and image.
polkastarter.ai
![image](https://user-images.githubusercontent.com/49607867/113023756-a4ba7a00-918e-11eb-844a-fea84f71c0cd.png)

Suspect bad "contract" 0x7b1Df8e80ce3F5AF35ed4B9c971916A7f62c847D