### PR TITLE
Added 1sgexchange[.]com

### DIFF
--- a/all.json
+++ b/all.json
@@ -1,6 +1,7 @@
 {
   "allow": [],
   "deny": [
+    "1sgexchange.com",
     "3xexchange.io",
     "4dot.net",
     "acala-token.live",


### PR DESCRIPTION
1sgexchange[.]com imitating 1sg stable coin and running a giveaway scam for DOT on TG (claimpolkadot[.]org)