### PR TITLE
Add new wallet connect clones

### DIFF
--- a/all.json
+++ b/all.json
@@ -84,6 +84,10 @@
     "wallet-linker.net",
     "wallet-syncing.com",
     "wallet-validation.site",
+    "walletbloksconnect.live",
+    "walletconnectbot.com",
+    "xn--wlletconnect-cbb.com",
+    "wallets-connect.net",
     "walletsynchronization.com",
     "web-polkadot.web.app"
   ]


### PR DESCRIPTION
wallets-connect.net ➡ https://urlscan.io/result/e2fc43a1-a8ec-438a-a194-ee3f5bc62578/
walletbloksconnect.live ➡ https://urlscan.io/result/8eb53d9c-2a49-4a18-bde3-71580e23f215/
walletconnectbot.com ➡ https://urlscan.io/result/aadc4b34-7420-4a1b-aca1-0256bafd1c73/
xn--wlletconnect-cbb­.com ➡ https://urlscan.io/result/babc8cc6-c2c6-4c10-af2d-42c0b149bb8f/

Yesterday found those but trezor and uniswap dont support dot, so only adding the fake multi wallets.
First one may be present in another PR.

![image](https://user-images.githubusercontent.com/49607867/113376591-be201980-937a-11eb-8306-bddb7f8d1410.png)
