### PR TITLE
Add new bad URL

### DIFF
--- a/all.json
+++ b/all.json
@@ -77,6 +77,7 @@
     "polkamon.whitelist-network.com",
     "polkastarter.ai",
     "polkastarter.ws",
+    "polkastarter.cm",
     "polkawallets.site",
     "polkdot-live.network",
     "polkodot.network",


### PR DESCRIPTION
Freshly registered. Scam is not yet set up.

Bad IP hosting many other phish.
https://www.virustotal.com/gui/ip-address/198.54.126.114/relations
![image](https://user-images.githubusercontent.com/49607867/113380980-67204180-9386-11eb-9db6-bfcc8c07cb24.png)

Based on the registrar + bad IP combo = blocking in advance, no need to wait for scam to be setup.