### PR TITLE
Add new bad URL

### DIFF
--- a/all.json
+++ b/all.json
@@ -52,6 +52,7 @@
     "polkadot-online.com",
     "polkadot-online.live",
     "polkadot-promo.info",
+    "polkadot-promo.net",
     "polkadot-support.com",
     "polkadot-wallet.com",
     "polkadot-wallet.org",


### PR DESCRIPTION
add confirmed scam polkadot-promo.net ➡https://urlscan.io/result/5c98dda9-02bb-4d7c-8445-d22bf65e2520/

advancedpolkadot[.]com - "info@blockchain.st" 💁‍♂️😕
goldpolkadot[.]com - "info@blockchain.st" 💁‍♂️😕
polkadot[.]casa/#top-widget1 - some sort of bitcoin ponzi, not related to DOT, ignoring
polkadotsevent[.]com - landing page, will monitor it
polkadot365[.]com - landing page, will monitor it
polkadotbank[.]com - "info@blockchain.st" 💁‍♂️😕