### PR TITLE
add new bad URL

### DIFF
--- a/all.json
+++ b/all.json
@@ -12,6 +12,7 @@
     "claimpolka.live",
     "claimpolkadot.com",
     "claimpolkadot.org",
+    "claimpolkadot.network",
     "dot-event.news",
     "dot-event.org",
     "dot21.net",


### PR DESCRIPTION
registered today
![image](https://user-images.githubusercontent.com/49607867/113468769-ed08bf00-9450-11eb-90dd-274f102a5e2b.png)
claimpolkadot.network

Notice how Registrar & hosting (same firm) have failed to remove a scam of the same type, reported on the 25th March:
https://twitter.com/dubstard/status/1378016587396087810
Still up 10 days later.
