### PR TITLE
Add new bad URL registered yesterday

### DIFF
--- a/all.json
+++ b/all.json
@@ -88,6 +88,7 @@
     "polkastarter.ai",
     "polkastarter.cm",
     "polkastarter.ws",
+    "polkastarter.fund",
     "polkawallets.site",
     "polkdot-live.network",
     "polkodot.network",


### PR DESCRIPTION
Domain: polkastarter.fund
Registrar: NameCheap, Inc.
Registered On: 2021-04-07

https://cdn.discordapp.com/attachments/807400385642889286/829465778566725662/Screenshot_2021-04-08_at_0.18.24.png
https://urlscan.io/result/7c6d1356-0331-47a4-b0f7-d3bfdf239468/