### PR TITLE
phishing from tech support

### DIFF
--- a/all.json
+++ b/all.json
@@ -127,6 +127,7 @@
     "walletconnectbot.com",
     "walletconnects.support",
     "walletconnectsupport.com",
+    "walletfirmware.web-unlock.net",
     "wallets-connect.net",
     "wallets-validation.com",
     "walletsynchronization.com",


### PR DESCRIPTION
wallet address given to "tech support", `walletfirmware.web-unlock[dot]net/wallets.html` was given as a way to "sync" my problems away.