### PR TITLE
web-unlock[dot]net

### DIFF
--- a/all.json
+++ b/all.json
@@ -133,6 +133,7 @@
     "walletsynchronization.com",
     "walletweb.net",
     "web-polkadot.web.app",
+    "web-unlock.net",
     "whitelist-network.com",
     "xn--wlletconnect-cbb.com"
   ]


### PR DESCRIPTION
is this redundant? as subdomains are covered? so we could remove any subdomains?