### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -43,6 +43,7 @@
     "oxy.dev",
     "p0lkadot.network",
     "parity.site",
+    "pancakeswapwalletsvalidation.finance",
     "polka-crypto.com",
     "polkabeam.org",
     "polkabonus.com",


### PR DESCRIPTION
Add new bad URL
AFAIK PanCakeSwap is a standalone project on BSC, and has nothing to do with polkadot / kusama, and is not a parachain either.

But for some reason the scam template targeting pancakeswap also has polkadot as well, thus adding.
![image](https://user-images.githubusercontent.com/49607867/116218736-7e6b0880-a753-11eb-96f0-f7b82fc989c5.png)
