### PR TITLE
Removing polkassembly.network. It is valid created for testing moonbase alpha network.

### DIFF
--- a/all.json
+++ b/all.json
@@ -163,7 +163,6 @@
     "polkapool.live",
     "polkascanner.com",
     "polkasot.js.org",
-    "polkassembly.network",
     "polkastarter.ai",
     "polkastarter.cc",
     "polkastarter.cm",

--- a/urlmeta.json
+++ b/urlmeta.json
@@ -85,10 +85,6 @@
   },
   {
     "date": "2021-05-05",
-    "url": "polkassembly.network"
-  },
-  {
-    "date": "2021-05-05",
     "url": "polkastartor.com"
   },
   {


### PR DESCRIPTION
https://moonbase.polkassembly.network/