### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -390,6 +390,8 @@
     "supportwalletrestore.com",
     "synchronizetrustwallet.com",
     "syncwalletlive.com",
+    "syncprocess.me",
+    "syncprocess.live",
     "tempuswallet.com",
     "tendieswap.info",
     "the-trust-project.com",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49607867/120980169-05fa5d00-c77f-11eb-811c-aa1c2b1bc33b.png)

![image](https://user-images.githubusercontent.com/49607867/120980177-08f54d80-c77f-11eb-82e7-701692001f0f.png)

![image](https://user-images.githubusercontent.com/49607867/120980195-0dba0180-c77f-11eb-8235-2dbbde65c2f8.png)

Scammers lurking on discord.

Whenever a user needs help they slide in to their DM like Yo bruh i had the same issue, you only need to "synchronize" your wallet and you are all set.
The IP address tied to both scum domains is https://www.virustotal.com/gui/ip-address/198.54.115.92/relations and has historically been used in all sorts of cyber crime.

As usual powered by the company who "has zero tolerance toward phishing"

https://twitter.com/TrevorGiffen/status/1327302984729042944
https://twitter.com/dubstard/status/1329829998958669826

Some interesting links regarding this service provider:
https://www.theregister.com/2018/02/07/namecheap_subdomain_security_hole/

https://davidamerland.com/seo-blog/1028-namecheap-is-a-safe-harbor-for-phishing-websites-case-study.html

https://securityaffairs.co/wordpress/99138/social-networks/facebook-namecheap-domain-name-fraud.html

https://twitter.com/search?q=namecheap%20scam&src=typed_query

https://spamreports.report/post/619149699680813056/ebay-scam-the-scammer-uses-attractive-items-on

https://petscams.com/news/namecheap-hurting-internet/

https://www.bootlesshacker.com/namecheap-and-phishers/

https://krebsonsecurity.com/2018/06/bad-men-at-work-please-dont-click/

https://theantisocialengineer.com/2021/02/12/we-all-work-for-namecheap/
