### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -217,6 +217,7 @@
     "finance-swap-liquidity-v2.site",
     "finance-swap-v2-liquidity.site",
     "get-dot.me",
+    "get-polkadot.net",
     "getblockchain.digital",
     "getcoinwallet.com",
     "getmusk.top",


### PR DESCRIPTION
No evident bad content yet (have not tried fuzzing nor subdomain scans), blacklisting in advance simply based on where it is "hosted" 
DDOS Guard DDNS Passthrough reverse proxy, not actual hosting) I can bet what it will host even before they have spun it up.
It would most likely be a RemcosRAT or NetWireRAT posing as "mandatory update". 

Then they spam the discord and social media channels 
"hey, install the New Mandatory polkadot y'all"

A few examples:

https://twitter.com/dubstard/status/1374804489367080968
https://twitter.com/dubstard/status/1371554138757206030
https://twitter.com/dubstard/status/1385658148032323584