### PR TITLE
Add paritytech.io

### DIFF
--- a/all.json
+++ b/all.json
@@ -557,6 +557,7 @@
     "paralink.polkastarter.com.es",
     "paralink.polkastarter.com.pl",
     "parity.site",
+    "paritytech.io",
     "paxful-com.com",
     "peercoinwallet.com",
     "phuture.medium.cn.com",


### PR DESCRIPTION
Website redirects to parity.io, but emails from paritytech.io are being used for phishing scams (asking for "deposits" to take part in grant programs)