### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -647,6 +647,7 @@
     "polkadot.gg",
     "polkadot.me",
     "polkadot.money",
+    "polkadot.nyc",
     "polkadot.network.erc-20-airdrop-rewards.site",
     "polkadot.promo",
     "polkadot.site",


### PR DESCRIPTION
there is also polkadot[.]org - seems bad (unless owned by the Polkadot team)
![image](https://user-images.githubusercontent.com/49607867/138062566-22f99289-5f59-4aae-a617-419e42e7f707.png)

and polkadot-china[.]com
Only has referral links (i.e. someone earns a small interest if a person signs up on any CEX using one of those links)