### PR TITLE
Fake polkadot site

### DIFF
--- a/all.json
+++ b/all.json
@@ -1787,6 +1787,7 @@
     "elrond22.org",
     "embertokencrypto.com",
     "emetamasks.com",
+    "emily.ghost.io",
     "emulefinance.io",
     "emuskgives.com",
     "en-metamask.com",


### PR DESCRIPTION
main page redirects to polkadot.network

https://emily.ghost.io/ghost/ asks you to "log in to Polkadot"