### PR TITLE
Remove emily.ghost.io

### DIFF
--- a/all.json
+++ b/all.json
@@ -2711,7 +2711,6 @@
 		"elrond22.org",
 		"embertokencrypto.com",
 		"emetamasks.com",
-		"emily.ghost.io",
 		"empiretokenworld.com",
 		"emulefinance.io",
 		"emuskgives.com",


### PR DESCRIPTION
This is the direct link to the actual hosted site that polkadot.network uses