### PR TITLE
Remove defiyield.app from deny list

### DIFF
--- a/all.json
+++ b/all.json
@@ -2516,7 +2516,6 @@
 		"defiwalletswap.com",
 		"defiweb-interface.org",
 		"defixrectify.live",
-		"defiyield.app",
 		"deflkingdom.live",
 		"defo-collab.com",
 		"defocollab.land",


### PR DESCRIPTION
Hi! I'm getting the next message on try visiting defiyield.app
![image](https://user-images.githubusercontent.com/25538179/167122218-f61564b9-cb7a-422e-a58c-03850a2dd3f6.png)

Found it was added to deny list in #1544
I believe it was added by accident. Can it be explained or removed from the list, plz?
[Urlscan](https://urlscan.io/result/a7fa0bac-dfb4-4136-9b23-f31c7c055ff5/) also didn't find have any threats on this website