### PR TITLE
request to remove pasarprotocol.io from the list

### DIFF
--- a/all.json
+++ b/all.json
@@ -5268,7 +5268,6 @@
 		"parity.site",
 		"partenariat-metamask.com",
 		"partenariat.io",
-		"pasarprotocol.io",
 		"paulgoldhunter.com",
 		"paxful-com.com",
 		"paxful-token.com",

--- a/all.json
+++ b/all.json
@@ -7870,7 +7870,6 @@
 		"walletconnect.minehouse.tech",
 		"walletconnect.ml",
 		"walletconnect.nftswhitelist.info",
-		"walletconnect.pasarprotocol.io",
 		"walletconnect.plus",
 		"walletconnect.repair",
 		"walletconnect.se",


### PR DESCRIPTION
Request to remove pasarprotocol.io from the list based on the reason that Pasarprotocol.io is not built on Polkadot and Substrate networks. It's built on Elastos Smart Chain (ESC). We really have no ideas who put this domain name on this list and based on what reason. 
Pasar is open-sourced, community-centric, and one of the first truly Web3.0 decentralized marketplaces (DeMKT) for exchanging data and Non-fungible Tokens (NFTs) fully based on Elastos ESC (Elastos Smart Chain) - https://pasarprotocol.io/
We would be appreciated it if you help check this and remove it from the list. 