### PR TITLE
fake RMRK kanaria land sale

### DIFF
--- a/all.json
+++ b/all.json
@@ -3759,6 +3759,7 @@
 		"juzztoken.com",
 		"kabyarenadev.com",
 		"kalao.online",
+		"kanaria-skybreach.sale",
 		"karafuru.gifts",
 		"karura-network.com",
 		"karura-networks.com",


### PR DESCRIPTION
active phishing scam, fake RMRK kanaria landsale site.
![image](https://user-images.githubusercontent.com/11927879/169709793-7955f62a-5c1d-4ae6-bf77-b3454b54cd96.png)
