### PR TITLE
Add weebly.com to top-level check

### DIFF
--- a/packages/phishing/src/additions.spec.ts
+++ b/packages/phishing/src/additions.spec.ts
@@ -27,6 +27,7 @@ const TOP_LEVEL = [
   'vercel.app',
   'web.app',
   'webflow.io',
+  'weebly.com',
   'wixsite.com',
   'zapto.org'
 ];


### PR DESCRIPTION
This ensures we don't add a naked `weebly.com` (which also has valid uses), to the `all.json` - subdomains from this is allowed, as normal.