### PR TITLE
Add reported URLs

### DIFF
--- a/all.json
+++ b/all.json
@@ -1,6 +1,18 @@
 {
 	"allow": [],
 	"deny": [
+		"binancechain.help",
+		"cardanofoundation.blog",
+		"app.mantradao.com",
+		"mantradao.com",
+		"giveaway-darwinia.com",
+		"smartcoiresolved.com",
+		"fastappsolutions.com",
+		"stepnactivties.com",
+		"2xdoublercloud.space",
+		"herowars.site",
+		"coinprelaunch.site",
+		"securealliance.net",
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",

--- a/all.json
+++ b/all.json
@@ -5,7 +5,6 @@
 		"cardanofoundation.blog",
 		"giveaway-darwinia.com",
 		"smartcoiresolved.com",
-		"fastappsolutions.com",
 		"stepnactivties.com",
 		"2xdoublercloud.space",
 		"herowars.site",

--- a/all.json
+++ b/all.json
@@ -3,8 +3,6 @@
 	"deny": [
 		"binancechain.help",
 		"cardanofoundation.blog",
-		"app.mantradao.com",
-		"mantradao.com",
 		"giveaway-darwinia.com",
 		"smartcoiresolved.com",
 		"fastappsolutions.com",


### PR DESCRIPTION
Closes https://github.com/polkadot-js/phishing/issues/1822

- The binancechain.help link is from the bit.ly - any other URL on this domain returns directly to binance.
- did not include mantradao.com - cannot determine if this is phishing
- did not include the toll links (non-crypto, even if a scam)