### PR TITLE
Allow surge.sh as a top-level domain

### DIFF
--- a/all.json
+++ b/all.json
@@ -14,6 +14,7 @@
 		"plesk.page",
 		"servehttp.com",
 		"square.site",
+		"surge.sh",
 		"sytes.net",
 		"timeweb.ru",
 		"vercel.app",


### PR DESCRIPTION
Static publishing site. Some phishing domains appeared on it in https://github.com/polkadot-js/phishing/pull/1900 - so we need to make sure we block the sub-domains, but also just protect that we don't inadvertently block the top-level.