### PR TITLE
Add duckdns.org to allowed top-level

### DIFF
--- a/all.json
+++ b/all.json
@@ -3,6 +3,7 @@
 		"*.fleek.co",
 		"ddns.net",
 		"ddns.us",
+		"duckdns.org",
 		"github.io",
 		"herokuapp.com",
 		"hopto.org",


### PR DESCRIPTION
Sadly, as with most free hosting services, it is probably a phishing trap since scammers can use it at will, e.g. https://blog.malwarebytes.com/detections/duckdns-org/

However, the service itself is legit, so shouldn't be blocked outright. (However domains on it will certainly make the list, e.g. https://github.com/polkadot-js/phishing/pull/1907)