### PR TITLE
Update all.json from Allure Security findings

### DIFF
--- a/all.json
+++ b/all.json
@@ -11479,6 +11479,17 @@
 		"zinotiger.com",
 		"zipwallet.net",
 		"zonefix.net",
-		"zwalletconnect.com"
+		"zwalletconnect.com",
+		"wallet-fix.xyz",
+		"walletsconnets.us",
+		"web3auths.com",
+		"nodeconfig.live",
+		"worldwdehost.jp",
+		"wilcoxgamboa-insurranceagency.cf",
+		"walletsconnectdaps.org",
+		"stapn.com",
+		"livechainsync.com",
+		"wallectconnetdapps.com",
+		"wallet-secure.info"
 	]
 }


### PR DESCRIPTION
These are the new sites for today and the corresponding top-level domains added to `all.json`.
Please keep in mind that the script checks against all.json from the master branch. If there are open PRs, there may be duplicates.
Also, please check if the domains added are any well-known that shouldn't be blacklisted at the top level (eg. netlify, ddns, etc) and change these to include the subdomain.

Please check them for eligibility and liveness, add the additional information (urlscan, screenshot) were applicable, and separate them in eligible, non-eligible and dead.
The curator should only copy the "eligible" ones into the spreadsheet.

Below are 19 new scam sites, along with 11 domains added to `all.json`:

| Site | Domain |
|------|--------|

### Eligible
| Site | Urlscan | Screenshot |
|-------|-------|-------|

### Non-eligible
| Site |
|-------|
| connect.tokenwaco.click | N/A |
| walletsconnets.us | walletsconnets.us |

### Dead
| Site |
|-------|
| wallets.appsregistry.net | N/A |
| wallets.appsregistry.online | N/A |
| wallet.appsregistry.online | N/A |
| wallet.appsregistry.net | N/A |
| m.fixmydapps.xyz | N/A |
| wallet-fix.xyz | wallet-fix.xyz |
| web3auths.com | web3auths.com |
| connect.nodeconfig.live | nodeconfig.live |
| wallet.accessfixapp.com | N/A |
| app.apptokensvalidator.com | N/A |
| worldwdehost.jp | worldwdehost.jp |
| wilcoxgamboa-insurranceagency.cf | wilcoxgamboa-insurranceagency.cf |
| walletsconnectdaps.org | walletsconnectdaps.org |
| stapn.com | stapn.com |
| livechainsync.com | livechainsync.com |
| wallectconnetdapps.com | wallectconnetdapps.com |
| wallet-secure.info | wallet-secure.info |