### PR TITLE
Update all.json from Allure Security findings

### DIFF
--- a/all.json
+++ b/all.json
@@ -11717,6 +11717,8 @@
 		"zinotiger.com",
 		"zipwallet.net",
 		"zonefix.net",
-		"zwalletconnect.com"
+		"zwalletconnect.com",
+		"blockchainconnect.tk",
+		"defsyn.com"
 	]
 }


### PR DESCRIPTION
These are the new sites for today and the corresponding top-level domains added to `all.json`.
Please keep in mind that the script checks against all.json from the master branch. If there are open PRs, there may be duplicates.
Also, please check if the domains added are any well-known that shouldn't be blacklisted at the top level (eg. netlify, ddns, etc) and change these to include the subdomain.

Please check them for eligibility and liveness, add the additional information (urlscan, screenshot) were applicable, and separate them in eligible, non-eligible and dead.
The curator should only copy the "eligible" ones into the spreadsheet.

Below are 2 new scam sites, along with 2 domains added to `all.json`:

| Site | Domain |
|------|--------|
| blockchainconnect.tk | blockchainconnect.tk |
| defsyn.com | defsyn.com |


### Eligible
| Site | Urlscan | Screenshot |
|-------|-------|-------|
|defsyn.com|||
### Non-eligible
| Site |
|-------|
|blockchainconnect.tk|
### Dead
| Site |
|-------|
