### PR TITLE
remove web3helpers.xyz from deny list

### DIFF
--- a/all.json
+++ b/all.json
@@ -12551,7 +12551,6 @@
 		"web3defiexplorer.com",
 		"web3defiproject.com",
 		"web3dexconnect.com",
-		"web3helpers.xyz",
 		"web3host.online",
 		"web3host.tech",
 		"web3integrateddapp.pro",


### PR DESCRIPTION
Hi
Can I request to remove web3helpers.xyz from the deny list, I don't know how it was listed on deny list. I am the owner of the domain right now, and I am developing a new site for it.
The repo is here https://github.com/web3helpers/web3helpers
The deployed site is here https://web3tools-nu.vercel.app/apps/substrate/sign-message

Thanks!