### PR TITLE
add two fake airdrops

### DIFF
--- a/all.json
+++ b/all.json
@@ -28,6 +28,9 @@
 	],
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
+		"polkadot-airdrop.com",
+		"airdrop.xn--aptosabs-xkb.com",
+		"xn--aptosabs-xkb.com",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",

--- a/all.json
+++ b/all.json
@@ -30,6 +30,7 @@
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"polkadot-airdrop.com",
 		"airdrop.xn--aptosabs-xkb.com",
+		"polkadot-airdrop.com.hathor-airdrop.com",
 		"xn--aptosabs-xkb.com",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",


### PR DESCRIPTION
I checked the PRs and `airdrop.xn--aptosabs-xkb.com` and `polkadot-airdrop.com` were not blocked yet.
![image](https://user-images.githubusercontent.com/49607867/197372582-aac41d29-2b92-4280-9eed-2070fc711c89.png)
![image](https://user-images.githubusercontent.com/49607867/197372602-bebef9cf-60fa-4b7c-93d8-1013ee4bcf12.png)

They are fresh.