### PR TITLE
block correctiondapps.com

### DIFF
--- a/all.json
+++ b/all.json
@@ -28,6 +28,7 @@
 	],
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
+		"correctiondapps.com",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",


### PR DESCRIPTION
block 
```
"correctiondapps.com",
```

![image](https://user-images.githubusercontent.com/49607867/201610522-cee7cda9-9db0-4d32-afda-155b34ee0a1b.png)
![image](https://user-images.githubusercontent.com/49607867/201610581-d2c064f5-e109-4c14-bc98-b01f3b667485.png)

Seems dead already