### PR TITLE
block 4 polkastarter scams

### DIFF
--- a/all.json
+++ b/all.json
@@ -29,12 +29,10 @@
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"0vvwvuniswap.top",
-		
 		"polkastartrer.click",
 		"pollkastarter.co",
 		"polkastarterdasboert.com",
 		"www-polkastartar.com",
-		
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",
 		"0x0c4681e6c0235179ec3d4f4fc4df3d14fdd96017.xyz",

--- a/all.json
+++ b/all.json
@@ -29,6 +29,12 @@
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"0vvwvuniswap.top",
+		
+		"polkastartrer.click",
+		"pollkastarter.co",
+		"polkastarterdasboert.com",
+		"www-polkastartar.com",
+		
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",
 		"0x0c4681e6c0235179ec3d4f4fc4df3d14fdd96017.xyz",


### PR DESCRIPTION
```
		"polkastartrer.click",
		"pollkastarter.co",
		"polkastarterdasboert.com ",
		"www-polkastartar.com",
```


Polkastarter.click - from the same quality IP which brings you
```
/app-dodoerx.click
/app-questi3.click
/app-questy3.click
/app-quyest3.click
/chainlaink.click
/chainlinwk.click
/chainlist-shop.com
/chainllink.click
/chainnlink.click
/foundaition-app.click
/polkastartrer.click
/polygonqscan.click
/polygoonscan.click
/polygvonscan.click
/shapebshift.click
/shapershift.click
/shapeshhift.click
/shapeshifot.click
/shapeshifxt.click
/shapeshijft.click
/shapeshisft.click
/shapeshnift.click
/shapesihift.click
/shapezshift.click
/syinapseprotocol.click
/synaipseprotocol.click
/synapseprnotocol.click
/synapseproltocol.click
/synapseprotoncol.click
/synapserprotocol.click
/synapsesprotocol.click
/synapseyprotocol.click
```
and so on.

All are on less-than-honest infrastructure (ddos guard ru), which says enough.
