### PR TITLE
block polkastqrtter.com and polkastqrter.com

### DIFF
--- a/all.json
+++ b/all.json
@@ -31,6 +31,8 @@
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",
+		"polkastqrtter.com",
+		"polkastqrter.com",
 		"0x0c4681e6c0235179ec3d4f4fc4df3d14fdd96017.xyz",
 		"0x2f499c6da2c8784063bb7e0cb1c478687210cdbr615.xyz",
 		"0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24.xyz",


### PR DESCRIPTION
fake BS,  the norm for this provider
```
polkastqrtter.com
polkastqrter.com
```
https://urlscan.io/result/c8d60b9a-fcc7-4452-b668-4c3431ccf4d8/ 
https://urlscan.io/result/b020ed14-4870-48d0-bb60-92ec7a85807f/