### PR TITLE
Block 7 scam URLs

### DIFF
--- a/all.json
+++ b/all.json
@@ -30,6 +30,13 @@
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"0vvwvuniswap.top",
+		"metmaxe.com",
+		"en-metam.com",		
+		"explore-opensese.com",
+		"exploreopensea.com",
+		"rocketpoal.com",
+		"rocketpool-stake.com",
+		"rocketpool-staking.com",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",
 		"0x0c4681e6c0235179ec3d4f4fc4df3d14fdd96017.xyz",


### PR DESCRIPTION
Block scams residing on the same [IP](https://www.virustotal.com/gui/ip-address/34.28.174.58/relations) as `en-polkastarter.com` and `polkastatrer.com`
```
		"metmaxe.com",
		"en-metam.com",		
		"explore-opensese.com",
		"exploreopensea.com",
		"rocketpoal.com",
		"rocketpool-stake.com",
		"rocketpool-staking.com",
```