### PR TITLE
Retrieve top-level domain lists

### DIFF
--- a/packages/phishing/src/index.spec.ts
+++ b/packages/phishing/src/index.spec.ts
@@ -3,8 +3,6 @@
 
 import { checkAddress, checkIfDenied } from '.';
 
-// *sigh* Jest breaks yet again...
-
 describe('checkIfDenied', (): void => {
   it('returns false when host is not listed', async (): Promise<void> => {
     expect(


### PR DESCRIPTION
Instead of always retrieving the top-level `all.json` this will now split the call into the `all/<domain>/all.json` list for retrieval. This means we get less data at once. Caching is now on a per-domain basis. (The term "domain" is used loosely, since a TLD would be `.co.uk`, but here it only refers to the `.uk` part)