### PR TITLE
Block 3 misspelled Polkastarter scams

### DIFF
--- a/all.json
+++ b/all.json
@@ -29,6 +29,9 @@
 	],
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
+		"polkaqstarter.com",
+		"polkastharter.com",
+		"polklastarter.com",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",


### PR DESCRIPTION
From the [same hosting](https://www.virustotal.com/gui/ip-address/185.224.139.97/relations) that brought you quality content, such as:
```
dapp-seedlfy.com
dapp-seedlfy.org
et7gtr5-icbc.app
guildofguaridnes.com
icbc10100auth.com
instanst.co
pay-secure.net
polkaqstarter.com
polkasaterter.com
polkasterater.com
polkastharter.com
polklastarter.com
seedfiy.com
seedfiy.org
seedlfy-fund.nl
seedlfy.nl
seedlfy.pl
sseedify.com
vps.nobula.net
www.dapp-seedlfy.com
www.guildofguaridnes.com
www.instanst.co
www.pay-secure.net
www.polkaqstarter.com
www.polkasaterter.com
www.polkasterater.com
www.polkastharter.com
www.seedfiy.com
www.seedfiy.org
www.seedlfy-fund.nl
www.seedlfy.nl
www.seedlfy.pl
www.sseedify.com
```
Trying to find a legitimate website here is as effective as pissing against a waterfall.