### PR TITLE
Add https://keplr-wallet.at/ to denylist

### DIFF
--- a/all.json
+++ b/all.json
@@ -7368,7 +7368,7 @@
 		"kendribase.tools",
 		"kepeyse.site",
 		"keplr-app.net",
-		"https://keplr-wallet.at/",
+		"keplr-wallet.at",
 		"keplr.online",
 		"keplr.site",
 		"kereves.site",

--- a/all.json
+++ b/all.json
@@ -7368,6 +7368,7 @@
 		"kendribase.tools",
 		"kepeyse.site",
 		"keplr-app.net",
+		"https://keplr-wallet.at/",
 		"keplr.online",
 		"keplr.site",
 		"kereves.site",


### PR DESCRIPTION
Adding https://keplr-wallet.at/ to deny list.

Phising link is used in this [Polkadot treasury proposal](https://polkadot.polkassembly.io/treasury/238).