### PR TITLE
Align tsconfig to allow moduleResolution: nodenext

### DIFF
--- a/packages/phishing/src/bundle.ts
+++ b/packages/phishing/src/bundle.ts
@@ -1,7 +1,7 @@
 // Copyright 2020-2023 @polkadot/phishing authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AddressList, HostList } from './types';
+import type { AddressList, HostList } from './types.js';
 
 import { u8aEq } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,10 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "paths": {
-      "@polkadot/phishing": ["phishing/src"],
-      "@polkadot/phishing/*": ["phishing/src/*"]
+      "@polkadot/phishing": ["phishing/src"]
     },
-    "skipLibCheck": true,
-    "target": "es2020"
+    "skipLibCheck": true
   }
  }


### PR DESCRIPTION
Follow-up for https://github.com/polkadot-js/api/issues/5524 (when we finally enable "moduleResolution": "nodenext" in @polkadot/dev)