### PR TITLE
added opensea-pro.com to the deny list 

### DIFF
--- a/all.json
+++ b/all.json
@@ -10743,6 +10743,7 @@
 		"openwalletuserhellp.company",
 		"ophiophagous-smiley-unvascular.s3.eu-central-003.backblazeb2.com",
 		"opnesee.net",
+		"opensea-pro.com",
 		"opnseawhitelist.com",
 		"opolkadot.js.org",
 		"oppolkadot.js.org",


### PR DESCRIPTION
opensea impersonator found, phishing link: opensea-pro.com
original link : https://pro.opensea.io/

adding screenshot for reference: 
![image](https://user-images.githubusercontent.com/75181701/230268433-69413e9b-a1d6-414f-b82b-b2240a96e5a1.png)

urlscan link: https://urlscan.io/result/1f349d06-3ca7-4309-8d7f-9429df68bbe3/