### PR TITLE
galxe impersonator found 

### DIFF
--- a/all.json
+++ b/all.json
@@ -6816,6 +6816,7 @@
 		"fxtimetrade247.com",
 		"fyvyyygy.xyz",
 		"gabrielknowles.com",
+		"galxe.trade",
 		"galaxy-dapinx.store",
 		"galaxygoggle.fund",
 		"gallaxystanix.ng",


### PR DESCRIPTION
galxe impersonator found
phishing link : https://galxe.trade/airdrop/ 
original link: Galxe.com
attaching a screen shot, 
![image](https://user-images.githubusercontent.com/75181701/230758454-bf122745-447f-43d0-b814-877b70126b5d.png)


attaching a urlscan link also : https://urlscan.io/result/22797edb-bc02-443a-a26f-ed7635f32467/ 