### PR TITLE
fake vela exchange airdrop

### DIFF
--- a/all.json
+++ b/all.json
@@ -15703,6 +15703,7 @@
 		"vcoin.digital",
 		"vechainthewallet.org",
 		"vee-friends-collab.land",
+		"veia.app",
 		"vela-exchange.tech",
 		"veleksupant.site",
 		"vempire-ddao-rewards-claims-erc20-token.my.id",


### PR DESCRIPTION
fake vela exchange impersnator found (airdrop scam)
impersonator link: veia.app
original link: app.vela.exchange

attaching a screenshot for reference:
![image](https://user-images.githubusercontent.com/75181701/232675802-9104c38e-416e-4dc2-bb96-25edab8590b8.png)

also adding the urlscan link:https://urlscan.io/result/bdebce93-bfa3-4b09-ba11-9bef6d5a1bcf/