### PR TITLE
premint impersonator found.

### DIFF
--- a/all.json
+++ b/all.json
@@ -11929,6 +11929,7 @@
 		"pradtorchainx.org.ng",
 		"prayersave.com",
 		"prcivnote.com",
+		"precmint.xyz",
 		"prefertoken.com",
 		"premint-submit.xyz",
 		"premium-poe.com",


### PR DESCRIPTION
impersonator link: precmint.xyz (it redirects to the official premint site so I have attached the complete url)
phishing link: https://precmint.xyz/Pacemaker/
original link: premint.xyz
![image](https://user-images.githubusercontent.com/75181701/232992935-e39234bc-c33e-4c26-9205-f08f0cc2ed65.png)

attaching a screenshot of the impersonator link:
attaching a url scan link:https://urlscan.io/result/1a7f3b19-1b3e-4fb7-a61f-708ffc6f11cd/