### PR TITLE
block polkasttarters-ido.com

### DIFF
--- a/all.json
+++ b/all.json
@@ -30,6 +30,7 @@
 	],
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
+		"polkasttarters-ido.com",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",


### PR DESCRIPTION
block polkasttarters-ido.com
Hosted on Shiniru MY, IP 78.40.143.48
This IP hosts only less than honest content.
Same for the full ASN AS 45839 ( Shinjiru Technology Sdn Bhd )
Black hat hosting used only by cyber criminal rats, nobody else.

![image](https://user-images.githubusercontent.com/49607867/233287423-b22ef3e1-6a68-401d-963b-fb31f8df4e00.png)



```
Malware and crypto crap
/everydayfeed.cfd
/huzokumap.com
/localinformation.online
/weare24px.club
/daily-time.website
/dailyfeed24.shop
/demergon-funds.com
/auto-eth.org
DHS US GOVT
/dhs-gov-esta.us
/dsa-assist.com

CANADA GOVT VISA
/eta-canadavisa.com

POSTBANK
/reparieren-de-postbank.live

BANK OF AMERICA
/secure-bankofamerica01e.com

VISA US GOVT
/usa-entry-esta.us
/visitnewzealand-eta.com
/govuk-theorydvsa.info
/evw-visa.com
```