### PR TITLE
Block 6 scam URLs

### DIFF
--- a/all.json
+++ b/all.json
@@ -30,6 +30,12 @@
 	],
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
+		"dappscoinconnect.pages.dev",
+		"whitelist-airdop.com",
+		"fast-airdrops.com",
+		"airdrop-live.xyz",
+		"trustconnectuser.com", 
+		"metadropcoinfree.com",
 		"0vvwvuniswap.top",
 		"0vvwwuniswap.top",
 		"0vwwuniswap.top",


### PR DESCRIPTION
blocks scams
```
		"dappscoinconnect.pages.dev",
		"whitelist-airdop.com",
		"fast-airdrops.com",
		"airdrop-live.xyz",
		"trustconnectuser.com", 
		"metadropcoinfree.com",
```

https://urlscan.io/result/ec599bbb-3f80-4389-ad38-381cd2d787dc/
https://urlscan.io/result/72098289-9f74-4b5d-bb9e-011af1c1f2ef/
https://urlscan.io/ip/78.40.143.15
https://urlscan.io/search/#filename%3A%22drainer.js%22%20AND%20date%3A%3Enow-1d