### PR TITLE
Add missing site entries

### DIFF
--- a/all.json
+++ b/all.json
@@ -29,6 +29,8 @@
 		"zapto.org"
 	],
 	"deny": [
+		"polkadonetwork.com",
+		"polkastarters-home.com",
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"09sync00.duckdns.org",
 		"0vvwvuniswap.top",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 @polkadot/dev authors & contributors
+// Copyright 2017-2023 @polkadot/phishing authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import baseConfig from '@polkadot/dev/config/eslint';


### PR DESCRIPTION
Adds `polkadonetwork.com`, `polkastarters-home.com` as detected in https://github.com/polkadot-js/phishing/issues/3784

(Closes https://github.com/polkadot-js/phishing/issues/3784)