### PR TITLE
block `moonbeam-netvvork.com`

### DIFF
--- a/all.json
+++ b/all.json
@@ -38,6 +38,7 @@
 		"0x-web3redrop.net",
 		"0x0c4681e6c0235179ec3d4f4fc4df3d14fdd96017.xyz",
 		"0x0portal.app",
+		"moonbeam-netvvork.com",
 		"0x0portal.com",
 		"0x0portal.net",
 		"0x2f499c6da2c8784063bb7e0cb1c478687210cdbr615.xyz",


### PR DESCRIPTION
block `moonbeam-netvvork.com [190.115.30.133]`
https://urlscan.io/ip/190.115.30.133

Tring to find a non scam site on this IP range, or on this full ASN as a matter of fact is a waste of time, as watching paint dry would be a more profitable activity, than dealing with annoying persistent cybercrime hosting providers.
```
General Info
Geo	Belize City, Belize (BZ) — 
AS	[AS59692](https://urlscan.io/asn/AS59692) - IQWEB, AE
Note: An IP might be announced by multiple ASs. This is not shown.
Registrar	RIPENCC

PTR	[ddos-guard.net](https://urlscan.io/domain/ddos-guard.net)
```