### PR TITLE
remove false positive metamask-snap-polkadot.pages.dev

### DIFF
--- a/all.json
+++ b/all.json
@@ -12405,7 +12405,6 @@
 		"metamask-restore.online",
 		"metamask-secure.com",
 		"metamask-secure.online",
-		"metamask-snap-polkadot.pages.dev",
 		"metamask-support.serveirc.com",
 		"metamask-supportdesk.com",
 		"metamask-sync.com",


### PR DESCRIPTION
remove false positive `metamask-snap-polkadot.pages.dev`
Reference: https://github.com/MetaMask/eth-phishing-detect/pull/13752 

This domain needs to be unblocked, it’s from ChainSafe, who are building the Polkadot Snap: `metamask-snap-polkadot.pages.dev`
Reference: https://github.com/ChainSafe/metamask-snap-polkadot/

Ping the Consensys (Metamask) team if you have any questions

Thanks

(i know, i dont trust pages.dev one bit either and i wish the project got a legit domain)
