### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -29,6 +29,7 @@
 		"zapto.org"
 	],
 	"deny": [
+		"synks.shop",
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"09sync00.duckdns.org",
 		"0kxwallet.org",


### PR DESCRIPTION
The domain synks.shop is used by impersonation scammers on Bloxstaking Discord server. The actual fake Blox phishing page is at https://bloxstakingx.synks.shop/restore/