### PR TITLE
Allow addition of denySub entries

### DIFF
--- a/all.json
+++ b/all.json
@@ -28853,5 +28853,8 @@
 		"zwalletconnect.com",
 		"zxcoin.website",
 		"zzcoin.website"
+	],
+	"denySub": [
+		"twitter.com/jacogr"
 	]
 }

--- a/all.json
+++ b/all.json
@@ -28855,6 +28855,6 @@
 		"zzcoin.website"
 	],
 	"denySub": [
-		"twitter.com/jacogr"
+		"x.com/jacogr"
 	]
 }

--- a/scripts/sortAll.mjs
+++ b/scripts/sortAll.mjs
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 // @ts-expect-error @polkadot/dev scripts don't have .d.ts files
 import { mkdirpSync, rimrafSync } from '@polkadot/dev/scripts/util.mjs';
 
-/** @typedef {{ allow: string[]; deny: string[]; denySub?: string[] }} AllList */
+/** @typedef {{ allow: string[]; deny: string[]; denySub: string[] }} AllList */
 
 const KNOWN_URLS = ['telegra.ph', 'twitter.com', 'youtube.com', 'x.com'];
 
@@ -232,7 +232,7 @@ const deny = sortSection(addSites(all, addr));
 const allJson = {
   allow: sortSection(all.allow),
   deny: rewriteSubs(deny),
-  denySub: sortSection(all.denySub || [], true)
+  denySub: sortSection(all.denySub, true)
 };
 
 // rewrite with all our entries (newline included)


### PR DESCRIPTION
Part of https://github.com/polkadot-js/phishing/issues/2417

This does not do checking of these paths in the actual API as of yet, however it allows the addition of sub-domain and path-based URLs inside `denySub`

So both these are planned and previous problematic -

- `x.com/jacogr`
- `jacogr.fleek.co`

These URLs can now be added to the `denySub` lists, and will be blocked when the actual API checks for these in a follow-up PR.

(Example of my twitter added, will drop that one at some point when the script _does_ check these, or when we have some in there)