### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -29,7 +29,7 @@
 		"zapto.org"
 	],
 	"deny": [
-		"ddnsking.com",
+		"wallconnectsync.ddnsking.com",
 		"singiular.net",
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"09sync00.duckdns.org",

--- a/all.json
+++ b/all.json
@@ -29,6 +29,8 @@
 		"zapto.org"
 	],
 	"deny": [
+		"ddnsking.com",
+		"singiular.net",
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"09sync00.duckdns.org",
 		"0kxwallet.org",


### PR DESCRIPTION
This was used in fake support scam on Allnodes Discord.

Fake WalletConnect page is located at https://wallconnectsync.ddnsking.com/restore

"Connect" page is at https://wallconnectsync.ddnsking.com/restore/explore/sync.html

And the stolen phrase/key would be sent via POST request to https://singiular.net/ws-secure/walletsynk.php