### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -11384,7 +11384,6 @@
 		"fetment.site",
 		"fex-walletsec.com",
 		"feykenenmsen.site",
-		"ff.io",
 		"ffixedfloat.org",
 		"ffixedflood.com",
 		"fflxedfload.com",


### PR DESCRIPTION
It's not a phishing website, it's the official new URL for FixedFloat. Their old URL: fixedfloat.com redirects to the new one.