### PR TITLE
Block hub-polkadot.com

### DIFF
--- a/all.json
+++ b/all.json
@@ -12883,6 +12883,7 @@
 		"httpslink.com",
 		"hub-injective-bke.pages.dev",
 		"hub-injective.network",
+		"hub-polkadot.com",
 		"hubconnect.me",
 		"hubfix.online",
 		"hubfix.rf.gd",


### PR DESCRIPTION
`
whois hub-polkadot.com

   Creation Date: 2024-03-20T14:00:45Z
   Registrar: NameSilo, LLC
`
![image](https://github.com/polkadot-js/phishing/assets/49607867/570f0761-b81e-419b-aabb-41eecd8991b7)
https://urlscan.io/result/6b58ab5b-532f-4c7b-b749-be5147e04a52/