### PR TITLE
- List of fake airdrops

### DIFF
--- a/all.json
+++ b/all.json
@@ -31,7 +31,6 @@
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"dappsradar.ms",
-		"dappradar.com",
 		"dappradar.at",
 		"etherfis.xyz",
 		"etherr.pro",

--- a/all.json
+++ b/all.json
@@ -30,6 +30,13 @@
 	],
 	"deny": [
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
+		"dappsradar.ms",
+		"dappradar.com",
+		"dappradar.at",
+		"etherfis.xyz",
+		"etherr.pro",
+		"puffersync.pages.dev",
+		"dappradar.onl",
 		"09sync00.duckdns.org",
 		"0kxwallet.org",
 		"0nlinebot.github.io",


### PR DESCRIPTION
"dappsradar.ms",
"dappradar.com",
"dappradar.at",
"etherfis.xyz",
"etherr.pro",
"puffersync.pages.dev",
"dappradar.onl",