### PR TITLE
Removed polkadot.world official distractive domain

### DIFF
--- a/all.json
+++ b/all.json
@@ -21502,7 +21502,6 @@
 		"polkadot.us.com",
 		"polkadot.whitelist-web3.com",
 		"polkadot.work",
-		"polkadot.world",
 		"polkadot1.js.org",
 		"polkadot100.js.org",
 		"polkadot2.js.org",


### PR DESCRIPTION
Removing polkadot.world which is now owned by distractive and exiled racers building the Consensus 2024 app for parity.