### PR TITLE
Update all.json

### DIFF
--- a/all.json
+++ b/all.json
@@ -30,7 +30,7 @@
 		"zapto.org"
 	],
 	"deny": [
-		".top",
+		"*.top",
 		"07e96d43-381a-46a3-9c16-6daf97213efc.co",
 		"09sync00.duckdns.org",
 		"0kxwallet.org",


### PR DESCRIPTION
The ".top" we currently have in the list is not working to block all sites using this level-1 domain. I'm no programmer, but, maybe, this will work? If not, I suggest we remove it from the list.