### PR TITLE
remove unlockpolkadot.com from deny list

### DIFF
--- a/all.json
+++ b/all.json
@@ -37796,7 +37796,6 @@
 		"unlock-wallet-connect.com",
 		"unlockallassets.com",
 		"unlockassetchain.com",
-		"unlockpolkadot.com",
 		"unlockserver.land",
 		"unlsswapp.com",
 		"unlsvapp.com",


### PR DESCRIPTION
unlockpolkadot.com is a genuine site which has been erroneously flagged as phishing. 