### PR TITLE
fix: remove nodelinkapp.xyz

### DIFF
--- a/all.json
+++ b/all.json
@@ -33611,7 +33611,6 @@
 		"nodeledger3.com",
 		"nodelify.live",
 		"nodelink-select.co",
-		"nodelinkapp.xyz",
 		"nodelive-sync.com",
 		"nodelive.firebaseapp.com",
 		"nodelive.sbs",


### PR DESCRIPTION
Closes #5707

Remove nodelinkapp.xyz from the phishing deny list after the domain was reacquired and repurposed.